### PR TITLE
Click should be handled by label, not input

### DIFF
--- a/src/radioBtn.vue
+++ b/src/radioBtn.vue
@@ -1,5 +1,6 @@
 <template>
   <label class="btn"
+  @click="handleClick"
   v-bind:class="{
     'active':active,
     'btn-success':type == 'success',
@@ -12,7 +13,6 @@
 
     <input type="radio" autocomplete="off"
       :checked="checked"
-      @click="handleClick"
     />
 
     <slot></slot>


### PR DESCRIPTION
Since bootstrap hides the inputs, clicks don't happen on them.